### PR TITLE
Memory optimize

### DIFF
--- a/sample/params_patch.m
+++ b/sample/params_patch.m
@@ -38,6 +38,6 @@ enzo_HDF5_flag  = true;
 gadget_bin_flag = false;  %% Not implemented yet
 
 %% Decide whether to use memory-optimized routine (when bccomics crashes)
-%% Saves about 24*Nmode_p^3 bytes.
+%% Saves about 32*Nmode_p^3 bytes.
 %% This will somewhat slow down calculation
 memory_save = true;

--- a/sample/params_patch.m
+++ b/sample/params_patch.m
@@ -36,3 +36,8 @@ particlevelocity_accuracyflag = true;
 enzo_bin_flag   = true;
 enzo_HDF5_flag  = true;
 gadget_bin_flag = false;  %% Not implemented yet
+
+%% Decide whether to use memory-optimized routine (when bccomics crashes)
+%% Saves about 24*Nmode_p^3 bytes.
+%% This will somewhat slow down calculation
+memory_save = true;

--- a/src/Generate_IC.m
+++ b/src/Generate_IC.m
@@ -8,7 +8,7 @@
 
 %% For memory-efficient 2D interpolation, will slice k-space cube by this number
 Nslice         = 16;  %% intended # of coarse slices; may differ from the actual # of coarse slices
-if (Nmode_p <= 64)  %% safeguard & efficiency for poor-resolution IC
+if (Nmode_p <= 32)  %% safeguard & efficiency for poor-resolution IC
   Nslice = 1
 end
 Nsubslice      = floor(Nmode_p/Nslice);
@@ -42,15 +42,30 @@ end
 %% We will cure this by nullifying monopole anyway down below (**).
 disp('----- Interpolating transfer function -----');
 dc  = zeros(Nmode_p,Nmode_p,Nmode_p);
-for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+if ~memory_save
+  dc  = interp2(muext,log(ksampletab), deltasc,  costh_k_V, 0.5*log(ksq_p),interp2opt);  %% dc still k-space values here.
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
     end
-    dc(isstart:isend,:,:)  = interp2(muext,log(ksampletab), deltasc,  costh_k_V(isstart:isend,:,:),0.5*log(ksq_p(isstart:isend,:,:)),interp2opt);  %% dc still k-space values here.
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      dc(:,:,kkstart:kkend) = interp2(muext,log(ksampletab), deltasc,  costh_k_V(:,:,kkstart:kkend), 0.5*log(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2),interp2opt);  %% dc still k-space values
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      dc(:,:,kkstart:kkend) = interp2(muext,log(ksampletab), deltasc,  costh_k_V(:,:,kkstart:kkend), 0.5*log(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2),interp2opt);  %% dc still k-space values
+    end  
+  end
 end
-
 %% randomize, apply reality, and normalize
 disp('----- Convolving transfer function with random number -----');
 dc = rand_real_norm(dc,Nmode_p,Nc_p,randamp,randphs,Vbox_p);
@@ -61,17 +76,66 @@ dc = rand_real_norm(dc,Nmode_p,Nc_p,randamp,randphs,Vbox_p);
 %% derived after above normalization on dc.
 %% ------------- cpos1 ----------------------
 disp('----- Calculating CDM position x -----');
-Psi1                 = i*k1_3D_p./ksq_p.*dc;
+if ~memory_save
+  Psi1                 = i*k1_3D_p./ksq_p.*dc;
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      Psi1(:,:,kkstart:kkend) = i*k1_3D_p_chunk            ./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*dc(:,:,kkstart:kkend);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      Psi1(:,:,kkstart:kkend) = i*k1_3D_p_chunk(:,:,1:Nsub)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*dc(:,:,kkstart:kkend);
+    end
+  end
+end
 Psi1(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
 Psi1                 = real(ifftn(ifftshift(Psi1)));
 
-xCDM_plane    =   Psi1(:,:,1) + k1_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
-xCDM_ex_plane = 5*Psi1(:,:,1) + k1_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+if ~memory_save
+  xCDM_plane    =   Psi1(:,:,1) + k1_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
+  xCDM_ex_plane = 5*Psi1(:,:,1) + k1_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+else
+  xCDM_plane    =   Psi1(:,:,1) + k1_3D_p_chunk(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
+  xCDM_ex_plane = 5*Psi1(:,:,1) + k1_3D_p_chunk(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+end
 
 %% Normalized position of particles in domain [0,1), cell-centered way. (enzo)
 %% If unperturbed(Psi=0), it should run [0.5, 1.5, ...., Nmode_p-0.5]/Nmode_p,
 %% For enzo, wrapping needed if perturbed potition is out of the domain [0, 1).
-Psi1 = mod((Psi1 + (k1_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+if ~memory_save
+  Psi1 = mod((Psi1 + (k1_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    if kkchunk ~= Nchunk
+      Psi1(:,:,kkstart:kkend) = mod((Psi1(:,:,kkstart:kkend) + (k1_3D_p_chunk            /kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      Psi1(:,:,kkstart:kkend) = mod((Psi1(:,:,kkstart:kkend) + (k1_3D_p_chunk(:,:,1:Nsub)/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+    end
+  end
+end
 
 if enzo_bin_flag
   fout = fopen([ICsubdir '/cpos1'], 'w');
@@ -102,14 +166,66 @@ end
 
 %% ------------- cpos2 ----------------------
 disp('----- Calculating CDM position y -----');
-Psi2                 = i*k2_3D_p./ksq_p.*dc;
+if ~memory_save
+  Psi2                 = i*k2_3D_p./ksq_p.*dc;
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      Psi2(:,:,kkstart:kkend) = i*k2_3D_p_chunk            ./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*dc(:,:,kkstart:kkend);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      Psi2(:,:,kkstart:kkend) = i*k2_3D_p_chunk(:,:,1:Nsub)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*dc(:,:,kkstart:kkend);
+    end
+  end
+end
 Psi2(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
 Psi2                 = real(ifftn(ifftshift(Psi2)));
 
-yCDM_plane    =   Psi2(:,:,1) + k2_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
-yCDM_ex_plane = 5*Psi2(:,:,1) + k2_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+if ~memory_save
+  yCDM_plane    =   Psi2(:,:,1) + k2_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
+  yCDM_ex_plane = 5*Psi2(:,:,1) + k2_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+else
+  yCDM_plane    =   Psi2(:,:,1) + k2_3D_p_chunk(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
+  yCDM_ex_plane = 5*Psi2(:,:,1) + k2_3D_p_chunk(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+end
 
-Psi2 = mod((Psi2 + (k2_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+%% Normalized position of particles in domain [0,1), cell-centered way. (enzo)
+%% If unperturbed(Psi=0), it should run [0.5, 1.5, ...., Nmode_p-0.5]/Nmode_p,
+%% For enzo, wrapping needed if perturbed potition is out of the domain [0, 1).
+if ~memory_save
+  Psi2 = mod((Psi2 + (k2_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    if kkchunk ~= Nchunk
+      Psi2(:,:,kkstart:kkend) = mod((Psi2(:,:,kkstart:kkend) + (k2_3D_p_chunk            /kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      Psi2(:,:,kkstart:kkend) = mod((Psi2(:,:,kkstart:kkend) + (k2_3D_p_chunk(:,:,1:Nsub)/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+    end
+  end
+end
 
 if enzo_bin_flag
   fout = fopen([ICsubdir '/cpos2'], 'w');
@@ -128,14 +244,68 @@ end
 
 %% ------------- cpos3 ----------------------
 disp('----- Calculating CDM position z -----');
-Psi3                 = i*k3_3D_p./ksq_p.*dc;
+if ~memory_save
+  Psi3                 = i*k3_3D_p./ksq_p.*dc;
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      Psi3(:,:,kkstart:kkend) = i*(k3_3D_p_chunk            +kshift)./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*dc(:,:,kkstart:kkend);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      Psi3(:,:,kkstart:kkend) = i*(k3_3D_p_chunk(:,:,1:Nsub)+kshift)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*dc(:,:,kkstart:kkend);
+    end
+  end
+end
 Psi3(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
 Psi3                 = real(ifftn(ifftshift(Psi3)));
 
-zCDM_plane    =   Psi3(:,:,1) + k3_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
-zCDM_ex_plane = 5*Psi3(:,:,1) + k3_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+if ~memory_save
+  zCDM_plane    =   Psi3(:,:,1) + k3_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
+  zCDM_ex_plane = 5*Psi3(:,:,1) + k3_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+else
+  zCDM_plane    =   Psi3(:,:,1) + k3_3D_p_chunk(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
+  zCDM_ex_plane = 5*Psi3(:,:,1) + k3_3D_p_chunk(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+end
 
-Psi3 = mod((Psi3 + (k3_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+%% Normalized position of particles in domain [0,1), cell-centered way. (enzo)
+%% If unperturbed(Psi=0), it should run [0.5, 1.5, ...., Nmode_p-0.5]/Nmode_p,
+%% For enzo, wrapping needed if perturbed potition is out of the domain [0, 1).
+if ~memory_save
+  Psi3 = mod((Psi3 + (k3_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      Psi3(:,:,kkstart:kkend) = mod((Psi3(:,:,kkstart:kkend) + ((k3_3D_p_chunk            +kshift)/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      Psi3(:,:,kkstart:kkend) = mod((Psi3(:,:,kkstart:kkend) + ((k3_3D_p_chunk(:,:,1:Nsub)+kshift)/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1);
+    end
+  end
+end
 
 if enzo_bin_flag
   fout = fopen([ICsubdir '/cpos3'], 'w');
@@ -174,13 +344,29 @@ clear dc  %% save memory
 %% Matlab & Octave 2D interpolation!! --> generating k-space deltas 
 disp('----- Interpolating transfer function -----');
 Thc  = zeros(Nmode_p,Nmode_p,Nmode_p);
-for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+if ~memory_save
+  Thc  = interp2(muext,log(ksampletab), deltasThc,  costh_k_V, 0.5*log(ksq_p),interp2opt);  %% Thc still k-space values here.
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
     end
-    Thc(isstart:isend,:,:)  = interp2(muext,log(ksampletab), deltasThc,  costh_k_V(isstart:isend,:,:),0.5*log(ksq_p(isstart:isend,:,:)),interp2opt);  %% dc still k-space values here.
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      Thc(:,:,kkstart:kkend) = interp2(muext,log(ksampletab), deltasThc,  costh_k_V(:,:,kkstart:kkend), 0.5*log(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2),interp2opt);  %% Thc still k-space values
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      Thc(:,:,kkstart:kkend) = interp2(muext,log(ksampletab), deltasThc,  costh_k_V(:,:,kkstart:kkend), 0.5*log(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2),interp2opt);  %% Thc still k-space values
+    end  
+  end
 end
 
 %% randomize, apply reality, and normalize
@@ -189,7 +375,30 @@ Thc = rand_real_norm(Thc,Nmode_p,Nc_p,randamp,randphs,Vbox_p);
 
 %% ------------- vc1 ----------------------
 disp('----- Calculating CDM velocity x -----');
-vc1(:,:,:)          = -i*af*k1_3D_p./ksq_p.*Thc(:,:,:);
+if ~memory_save
+  vc1(:,:,:)          = -i*af*k1_3D_p./ksq_p.*Thc(:,:,:);
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      vc1(:,:,kkstart:kkend) = -i*af*k1_3D_p_chunk            ./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*Thc(:,:,kkstart:kkend);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      vc1(:,:,kkstart:kkend) = -i*af*k1_3D_p_chunk(:,:,1:Nsub)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*Thc(:,:,kkstart:kkend);
+    end
+  end
+end
 vc1(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
 vc1                 = real(ifftn(ifftshift(vc1)));
 
@@ -201,13 +410,18 @@ if particlevelocity_accuracyflag
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (***)
   vc1 = padarray(vc1, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
   %% Find values at displaced particle locations
-  for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+  if ~memory_save
+    vc_1 = interpn(vc1, Psi1, Psi2, Psi3, interpnopt);
+  else
+    for kkchunk=1:Nchunk  %% interpolation done on spatial coordinate; kkchunk is just dummy index
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      vc_1(:,:,kkstart:kkend) = interpn(vc1, Psi1(:,:,kkstart:kkend), Psi2(:,:,kkstart:kkend), Psi3(:,:,kkstart:kkend), interpnopt);
     end
-    vc_1(isstart:isend,:,:) = interpn(vc1, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
   end
 end
 %% into enzo velocity unit, and rename back to vc1 from vc_1 (****)
@@ -234,7 +448,30 @@ clear vc1  %% save memory
 
 %% ------------- vc2 ----------------------
 disp('----- Calculating CDM velocity y -----');
-vc2(:,:,:)          = -i*af*k2_3D_p./ksq_p.*Thc(:,:,:);
+if ~memory_save
+  vc2(:,:,:)          = -i*af*k2_3D_p./ksq_p.*Thc(:,:,:);
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      vc2(:,:,kkstart:kkend) = -i*af*k2_3D_p_chunk            ./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*Thc(:,:,kkstart:kkend);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      vc2(:,:,kkstart:kkend) = -i*af*k2_3D_p_chunk(:,:,1:Nsub)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*Thc(:,:,kkstart:kkend);
+    end
+  end
+end
 vc2(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
 vc2                 = real(ifftn(ifftshift(vc2)));
 
@@ -246,13 +483,18 @@ if particlevelocity_accuracyflag
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (***)
   vc2 = padarray(vc2, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
   %% Find values at displaced particle locations
-  for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+  if ~memory_save
+    vc_2 = interpn(vc2, Psi1, Psi2, Psi3, interpnopt);
+  else
+    for kkchunk=1:Nchunk  %% interpolation done on spatial coordinate; kkchunk is just dummy index
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      vc_2(:,:,kkstart:kkend) = interpn(vc2, Psi1(:,:,kkstart:kkend), Psi2(:,:,kkstart:kkend), Psi3(:,:,kkstart:kkend), interpnopt);
     end
-    vc_2(isstart:isend,:,:) = interpn(vc2, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
   end
 end
 %% into enzo velocity unit, and rename back to vc2 from vc_2 (****)
@@ -271,7 +513,30 @@ clear vc2  %% save memory
 
 %% ------------- vc3 ----------------------
 disp('----- Calculating CDM velocity z -----');
-vc3(:,:,:)          = -i*af*k3_3D_p./ksq_p.*Thc(:,:,:);
+if ~memory_save
+  vc3(:,:,:)          = -i*af*k3_3D_p./ksq_p.*Thc(:,:,:);
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      vc3(:,:,kkstart:kkend) = -i*af*(k3_3D_p_chunk            +kshift)./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*Thc(:,:,kkstart:kkend);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      vc3(:,:,kkstart:kkend) = -i*af*(k3_3D_p_chunk(:,:,1:Nsub)+kshift)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*Thc(:,:,kkstart:kkend);
+    end
+  end
+end
 vc3(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
 vc3                 = real(ifftn(ifftshift(vc3)));
 
@@ -279,17 +544,22 @@ Vc3 = reshape(vc3(:,:,1) *MpcMyr_2_kms, Nmode_p, Nmode_p); %% for figure
 
 vc_3 = zeros(Nmode_p,Nmode_p,Nmode_p); %% temporary variable (see ****)
 if particlevelocity_accuracyflag
-  disp('******* Calculating CDM velocity y more accurately than 1LPT **');
-  %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
+  disp('******* Calculating CDM velocity z more accurately than 1LPT **');
+  %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (***)
   vc3 = padarray(vc3, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
   %% Find values at displaced particle locations
-  for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+  if ~memory_save
+    vc_3 = interpn(vc3, Psi1, Psi2, Psi3, interpnopt);
+  else
+    for kkchunk=1:Nchunk  %% interpolation done on spatial coordinate; kkchunk is just dummy index
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      vc_3(:,:,kkstart:kkend) = interpn(vc3, Psi1(:,:,kkstart:kkend), Psi2(:,:,kkstart:kkend), Psi3(:,:,kkstart:kkend), interpnopt);
     end
-    vc_3(isstart:isend,:,:) = interpn(vc3, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
   end
 end
 %% into enzo velocity unit, and rename back to vc3 from vc_3 (****)
@@ -328,13 +598,29 @@ clear Thc  %% save memory
 %% Matlab & Octave 2D interpolation!! --> generating k-space deltas 
 disp('----- Interpolating transfer function -----');
 db  = zeros(Nmode_p,Nmode_p,Nmode_p);
-for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+if ~memory_save
+  db  = interp2(muext,log(ksampletab), deltasb,  costh_k_V, 0.5*log(ksq_p),interp2opt);  %% db still k-space values here.
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
     end
-    db(isstart:isend,:,:)  = interp2(muext,log(ksampletab), deltasb,  costh_k_V(isstart:isend,:,:),0.5*log(ksq_p(isstart:isend,:,:)),interp2opt);  %% dc still k-space values here.
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      db(:,:,kkstart:kkend) = interp2(muext,log(ksampletab), deltasb,  costh_k_V(:,:,kkstart:kkend), 0.5*log(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2),interp2opt);  %% db still k-space values
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      db(:,:,kkstart:kkend) = interp2(muext,log(ksampletab), deltasb,  costh_k_V(:,:,kkstart:kkend), 0.5*log(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2),interp2opt);  %% db still k-space values
+    end  
+  end
 end
 
 %% randomize, apply reality, and normalize
@@ -346,46 +632,258 @@ db = rand_real_norm(db,Nmode_p,Nc_p,randamp,randphs,Vbox_p);
 if baryonparticleflag
   %% ------------- bpos1 ----------------------
   disp('----- Calculating baryon position x -----');
-  Psi1                 = i*k1_3D_p./ksq_p.*db;
+  if ~memory_save
+    Psi1                 = i*k1_3D_p./ksq_p.*db;
+  else
+    for kkchunk=1:Nchunk
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+      kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+      if kkchunk ~= Nchunk
+        Psi1(:,:,kkstart:kkend) = i*k1_3D_p_chunk            ./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*db(:,:,kkstart:kkend);
+      else %% the last chunk
+        if Nsub_r == 0
+          Nsub = Nsub_chunk;
+        else
+          Nsub = Nsub_r;
+        end
+        Psi1(:,:,kkstart:kkend) = i*k1_3D_p_chunk(:,:,1:Nsub)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*db(:,:,kkstart:kkend);
+      end
+    end
+  end
   Psi1(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
   Psi1                 = real(ifftn(ifftshift(Psi1)));
   fout = fopen([ICsubdir '/bpos1'], 'w');
-  fwrite(fout, mod((Psi1 + (k1_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+  if ~memory_save
+    fwrite(fout, mod((Psi1 + (k1_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+  else
+    for kkchunk=1:Nchunk
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      %% write in chunks: works only with k iteration and without header/footer chips
+      if kkchunk ~= Nchunk
+        fwrite(fout, mod((Psi1(:,:,kkstart:kkend) + (k1_3D_p_chunk            /kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+      else %% the last chunk
+        if Nsub_r == 0
+          Nsub = Nsub_chunk;
+        else
+          Nsub = Nsub_r;
+        end
+        fwrite(fout, mod((Psi1(:,:,kkstart:kkend) + (k1_3D_p_chunk(:,:,1:Nsub)/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+      end
+    end
+  end
   fclose(fout);
-  xbar_plane    =   Psi1(:,:,1) + k1_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
-  xbar_ex_plane = 5*Psi1(:,:,1) + k1_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in baryon position
+  if ~memory_save
+    xbar_plane    =   Psi1(:,:,1) + k1_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
+    xbar_ex_plane = 5*Psi1(:,:,1) + k1_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in baryon position
+  else
+    xbar_plane    =   Psi1(:,:,1) + k1_3D_p_chunk(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
+    xbar_ex_plane = 5*Psi1(:,:,1) + k1_3D_p_chunk(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in baryon position
+  end
   if particlevelocity_accuracyflag  
-    Psi1 = mod((Psi1 + (k1_3D_p/kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+    if ~memory_save
+      Psi1 = mod((Psi1 + (k1_3D_p/kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+    else
+      for kkchunk=1:Nchunk
+        disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+        kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+        kkend   = kkchunk*Nsub_chunk;
+        if kkchunk == Nchunk
+          kkend=Nmode_p;
+        end
+        if kkchunk ~= Nchunk
+          Psi1(:,:,kkstart:kkend) = mod((Psi1(:,:,kkstart:kkend) + (k1_3D_p_chunk            /kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+        else %% the last chunk
+          if Nsub_r == 0
+            Nsub = Nsub_chunk;
+          else
+            Nsub = Nsub_r;
+          end
+          Psi1(:,:,kkstart:kkend) = mod((Psi1(:,:,kkstart:kkend) + (k1_3D_p_chunk(:,:,1:Nsub)/kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+        end
+      end
+    end
   else
     clear Psi1  %% save memory
   end
   
   %% ------------- bpos2 ----------------------
   disp('----- Calculating baryon position y -----');
-  Psi2                 = i*k2_3D_p./ksq_p.*db;
+  if ~memory_save
+    Psi2                 = i*k2_3D_p./ksq_p.*db;
+  else
+    for kkchunk=1:Nchunk
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+      kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+      if kkchunk ~= Nchunk
+        Psi2(:,:,kkstart:kkend) = i*k2_3D_p_chunk            ./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*db(:,:,kkstart:kkend);
+      else %% the last chunk
+        if Nsub_r == 0
+          Nsub = Nsub_chunk;
+        else
+          Nsub = Nsub_r;
+        end
+        Psi2(:,:,kkstart:kkend) = i*k2_3D_p_chunk(:,:,1:Nsub)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*db(:,:,kkstart:kkend);
+      end
+    end
+  end
   Psi2(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
   Psi2                 = real(ifftn(ifftshift(Psi2)));
   fout = fopen([ICsubdir '/bpos2'], 'w');
-  fwrite(fout, mod((Psi2 + (k2_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+  if ~memory_save
+    fwrite(fout, mod((Psi2 + (k2_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+  else
+    for kkchunk=1:Nchunk
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      %% write in chunks: works only with k iteration and without header/footer chips
+      if kkchunk ~= Nchunk
+        fwrite(fout, mod((Psi2(:,:,kkstart:kkend) + (k2_3D_p_chunk            /kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+      else %% the last chunk
+        if Nsub_r == 0
+          Nsub = Nsub_chunk;
+        else
+          Nsub = Nsub_r;
+        end
+        fwrite(fout, mod((Psi2(:,:,kkstart:kkend) + (k2_3D_p_chunk(:,:,1:Nsub)/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+      end
+    end
+  end
   fclose(fout);
-  ybar_plane    =   Psi2(:,:,1) + k2_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
-  ybar_ex_plane = 5*Psi2(:,:,1) + k2_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+  if ~memory_save
+    ybar_plane    =   Psi2(:,:,1) + k2_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
+    ybar_ex_plane = 5*Psi2(:,:,1) + k2_3D_p(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+  else
+    ybar_plane    =   Psi2(:,:,1) + k2_3D_p_chunk(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure
+    ybar_ex_plane = 5*Psi2(:,:,1) + k2_3D_p_chunk(:,:,1)/kunit_p*Lcell_p + Lbox_p/2; %% for figure, NOT REAL but to make more contrast in CDM position
+  end
   if particlevelocity_accuracyflag
-    Psi2 = mod((Psi2 + (k2_3D_p/kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+    if ~memory_save
+      Psi2 = mod((Psi2 + (k2_3D_p/kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+    else
+      for kkchunk=1:Nchunk
+        disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+        kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+        kkend   = kkchunk*Nsub_chunk;
+        if kkchunk == Nchunk
+          kkend=Nmode_p;
+        end
+        if kkchunk ~= Nchunk
+          Psi2(:,:,kkstart:kkend) = mod((Psi2(:,:,kkstart:kkend) + (k2_3D_p_chunk             /kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+        else %% the last chunk
+          if Nsub_r == 0
+            Nsub = Nsub_chunk;
+          else
+            Nsub = Nsub_r;
+          end
+          Psi2(:,:,kkstart:kkend) = mod((Psi2(:,:,kkstart:kkend) + (k2_3D_p_chunk(:,:,1:Nsub)/kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+        end
+      end
+    end
   else
     clear Psi2  %% save memory
   end
   
   %% ------------- bpos3 ----------------------
   disp('----- Calculating baryon position z -----');
-  Psi3                 = i*k3_3D_p./ksq_p.*db;
+  if ~memory_save
+    Psi3                 = i*k3_3D_p./ksq_p.*db;
+  else
+    for kkchunk=1:Nchunk
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+      kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+      if kkchunk ~= Nchunk
+        Psi3(:,:,kkstart:kkend) = i*(k3_3D_p_chunk            +kshift)./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*db(:,:,kkstart:kkend);
+      else %% the last chunk
+        if Nsub_r == 0
+          Nsub = Nsub_chunk;
+        else
+          Nsub = Nsub_r;
+        end
+        Psi3(:,:,kkstart:kkend) = i*(k3_3D_p_chunk(:,:,1:Nsub)+kshift)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*db(:,:,kkstart:kkend);
+      end
+    end
+  end
   Psi3(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
   Psi3                 = real(ifftn(ifftshift(Psi3)));
   fout = fopen([ICsubdir '/bpos3'], 'w');
-  fwrite(fout, mod((Psi3 + (k3_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+  if ~memory_save
+    fwrite(fout, mod((Psi3 + (k3_3D_p/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+  else
+    for kkchunk=1:Nchunk
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      %% write in chunks: works only with k iteration and without header/footer chips
+      %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+      kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+      if kkchunk ~= Nchunk
+        fwrite(fout, mod((Psi3(:,:,kkstart:kkend) + ((k3_3D_p_chunk            +kshift)/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+      else %% the last chunk
+        if Nsub_r == 0
+          Nsub = Nsub_chunk;
+        else
+          Nsub = Nsub_r;
+        end
+        fwrite(fout, mod((Psi3(:,:,kkstart:kkend) + ((k3_3D_p_chunk(:,:,1:Nsub)+kshift)/kunit_p+0.5)*Lcell_p + Lbox_p/2)/Lbox_p, 1), 'double');
+      end
+    end
+  end
   fclose(fout);
   if particlevelocity_accuracyflag
-    Psi3 = mod((Psi3 + (k3_3D_p/kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+    if ~memory_save
+      Psi3 = mod((Psi3 + (k3_3D_p/kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+    else
+      for kkchunk=1:Nchunk
+        disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+        kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+        kkend   = kkchunk*Nsub_chunk;
+        if kkchunk == Nchunk
+          kkend=Nmode_p;
+        end
+        %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+        kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+        if kkchunk ~= Nchunk
+          Psi3(:,:,kkstart:kkend) = mod((Psi3(:,:,kkstart:kkend) + ((k3_3D_p_chunk            +kshift)/kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+        else %% the last chunk
+          if Nsub_r == 0
+            Nsub = Nsub_chunk;
+          else
+            Nsub = Nsub_r;
+          end
+          Psi3(:,:,kkstart:kkend) = mod((Psi3(:,:,kkstart:kkend) + ((k3_3D_p_chunk(:,:,1:Nsub)+kshift)/kunit_p)*Lcell_p + Lbox_p/2)/Lbox_p*Nmode_p, Nmode_p)+1;
+        end
+      end
+    end
   else
     clear Psi3  %% save memory
   end
@@ -428,18 +926,33 @@ clear db  %% save memory
 %% =========== baryon density ================================== end
 
 
-
 %% =========== baryon velocity ==================================== begin
 %% Matlab & Octave 2D interpolation!! --> generating k-space deltas 
 disp('----- Interpolating transfer function -----');
 Thb  = zeros(Nmode_p,Nmode_p,Nmode_p);
-for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+if ~memory_save
+  Thb  = interp2(muext,log(ksampletab), deltasThb,  costh_k_V, 0.5*log(ksq_p),interp2opt);  %% Thb still k-space values here.
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
     end
-    Thb(isstart:isend,:,:)  = interp2(muext,log(ksampletab), deltasThb,  costh_k_V(isstart:isend,:,:),0.5*log(ksq_p(isstart:isend,:,:)),interp2opt);  %% dc still k-space values here.
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      Thb(:,:,kkstart:kkend) = interp2(muext,log(ksampletab), deltasThb,  costh_k_V(:,:,kkstart:kkend), 0.5*log(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2),interp2opt);  %% Thb still k-space values
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      Thb(:,:,kkstart:kkend) = interp2(muext,log(ksampletab), deltasThb,  costh_k_V(:,:,kkstart:kkend), 0.5*log(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2),interp2opt);  %% Thb still k-space values
+    end  
+  end
 end
 
 %% randomize, apply reality, and normalize
@@ -448,7 +961,30 @@ Thb = rand_real_norm(Thb,Nmode_p,Nc_p,randamp,randphs,Vbox_p);
 
 %% ------------- vb1 ----------------------
 disp('----- Calculating baryon velocity x -----');
-vb1(:,:,:)          = -i*af*k1_3D_p./ksq_p.*Thb(:,:,:);
+if ~memory_save
+  vb1(:,:,:)          = -i*af*k1_3D_p./ksq_p.*Thb(:,:,:);
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      vb1(:,:,kkstart:kkend) = -i*af*k1_3D_p_chunk            ./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*Thb(:,:,kkstart:kkend);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      vb1(:,:,kkstart:kkend) = -i*af*k1_3D_p_chunk(:,:,1:Nsub)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*Thb(:,:,kkstart:kkend);
+    end
+  end
+end
 vb1(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
 vb1                 = real(ifftn(ifftshift(vb1)));
 %% add streaming velocity (V_cb = Vc - Vb)
@@ -483,13 +1019,18 @@ if (particlevelocity_accuracyflag & baryonparticleflag)
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
   vb1 = padarray(vb1, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
   %% Find values at displaced particle locations
-  for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+  if ~memory_save
+    vb_1 = interpn(vb1, Psi1, Psi2, Psi3, interpnopt);
+  else
+    for kkchunk=1:Nchunk  %% interpolation done on spatial coordinate; kkchunk is just dummy index
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      vb_1(:,:,kkstart:kkend) = interpn(vb1, Psi1(:,:,kkstart:kkend), Psi2(:,:,kkstart:kkend), Psi3(:,:,kkstart:kkend), interpnopt);
     end
-    vb_1(isstart:isend,:,:) = interpn(vb1, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
   end
   %% rename back to vb1 from vb_1 (****)
   vb1 = vb_1;
@@ -503,7 +1044,30 @@ clear vb1  %% save memory
 
 %% ------------- vb2 ----------------------
 disp('----- Calculating baryon velocity y -----');
-vb2(:,:,:)          = -i*af*k2_3D_p./ksq_p.*Thb(:,:,:);
+if ~memory_save
+  vb2(:,:,:)          = -i*af*k2_3D_p./ksq_p.*Thb(:,:,:);
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      vb2(:,:,kkstart:kkend) = -i*af*k2_3D_p_chunk            ./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*Thb(:,:,kkstart:kkend);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      vb2(:,:,kkstart:kkend) = -i*af*k2_3D_p_chunk(:,:,1:Nsub)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*Thb(:,:,kkstart:kkend);
+    end
+  end
+end
 vb2(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
 vb2                 = real(ifftn(ifftshift(vb2)));
 %% add streaming velocity (V_cb = Vc - Vb)
@@ -532,13 +1096,18 @@ if (particlevelocity_accuracyflag & baryonparticleflag)
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
   vb2 = padarray(vb2, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
   %% Find values at displaced particle locations
-  for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+  if ~memory_save
+    vb_2 = interpn(vb2, Psi1, Psi2, Psi3, interpnopt);
+  else
+    for kkchunk=1:Nchunk  %% interpolation done on spatial coordinate; kkchunk is just dummy index
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      vb_2(:,:,kkstart:kkend) = interpn(vb2, Psi1(:,:,kkstart:kkend), Psi2(:,:,kkstart:kkend), Psi3(:,:,kkstart:kkend), interpnopt);
     end
-    vb_2(isstart:isend,:,:) = interpn(vb2, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
   end
   %% rename back to vb2 from vb_2 (****)
   vb2 = vb_2;
@@ -552,7 +1121,30 @@ clear vb2  %% save memory
 
 %% ------------- vb3 ----------------------
 disp('----- Calculating baryon velocity z -----');
-vb3(:,:,:)          = -i*af*k3_3D_p./ksq_p.*Thb(:,:,:);
+if ~memory_save
+  vb3(:,:,:)          = -i*af*k3_3D_p./ksq_p.*Thb(:,:,:);
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      vb3(:,:,kkstart:kkend) = -i*af*(k3_3D_p_chunk            +kshift)./(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2).*Thb(:,:,kkstart:kkend);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      vb3(:,:,kkstart:kkend) = -i*af*(k3_3D_p_chunk(:,:,1:Nsub)+kshift)./(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2).*Thb(:,:,kkstart:kkend);
+    end
+  end
+end
 vb3(Nc_p,Nc_p,Nc_p) = complex(0);  %% fixing nan or inf monopole
 vb3                 = real(ifftn(ifftshift(vb3)));
 %% add streaming velocity (V_cb = Vc - Vb)
@@ -591,13 +1183,18 @@ if (particlevelocity_accuracyflag & baryonparticleflag)
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
   vb3 = padarray(vb3, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
   %% Find values at displaced particle locations
-  for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+  if ~memory_save
+    vb_3 = interpn(vb3, Psi1, Psi2, Psi3, interpnopt);
+  else
+    for kkchunk=1:Nchunk  %% interpolation done on spatial coordinate; kkchunk is just dummy index
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      vb_3(:,:,kkstart:kkend) = interpn(vb3, Psi1(:,:,kkstart:kkend), Psi2(:,:,kkstart:kkend), Psi3(:,:,kkstart:kkend), interpnopt);
     end
-    vb_3(isstart:isend,:,:) = interpn(vb3, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
   end
   %% rename back to vb3 from vb_3 (****)
   vb3 = vb_3;
@@ -621,13 +1218,29 @@ clear Thb  %% save memory
 %% Matlab & Octave 2D interpolation!! --> generating k-space deltas 
 disp('----- Interpolating transfer function -----');
 dT  = zeros(Nmode_p,Nmode_p,Nmode_p);
-for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+if ~memory_save
+  dT  = interp2(muext,log(ksampletab), deltasT,  costh_k_V, 0.5*log(ksq_p),interp2opt);  %% dT still k-space values here.
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend=Nmode_p;
     end
-    dT(isstart:isend,:,:)  = interp2(muext,log(ksampletab), deltasT,  costh_k_V(isstart:isend,:,:),0.5*log(ksq_p(isstart:isend,:,:)),interp2opt);  %% dc still k-space values here.
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      dT(:,:,kkstart:kkend) = interp2(muext,log(ksampletab), deltasT,  costh_k_V(:,:,kkstart:kkend), 0.5*log(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2),interp2opt);  %% dT still k-space values
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      dT(:,:,kkstart:kkend) = interp2(muext,log(ksampletab), deltasT,  costh_k_V(:,:,kkstart:kkend), 0.5*log(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2),interp2opt);  %% dT still k-space values
+    end  
+  end
 end
 
 %% randomize, apply reality, and normalize
@@ -723,13 +1336,18 @@ if (particlevelocity_accuracyflag & baryonparticleflag)
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
   dT = padarray(dT, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
   %% Find values at displaced particle locations
-  for islice=1:Nslice_actual
-    isstart = 1 + (islice-1)*Nsubslice;
-    isend   = islice*Nsubslice;
-    if islice == Nslice_actual
-      isend = Nmode_p;
+  if ~memory_save
+    dT_ = interpn(dT, Psi1, Psi2, Psi3, interpnopt);
+  else
+    for kkchunk=1:Nchunk  %% interpolation done on spatial coordinate; kkchunk is just dummy index
+      disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+      kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+      kkend   = kkchunk*Nsub_chunk;
+      if kkchunk == Nchunk
+	kkend=Nmode_p;
+      end
+      dT_(:,:,kkstart:kkend) = interpn(dT, Psi1(:,:,kkstart:kkend), Psi2(:,:,kkstart:kkend), Psi3(:,:,kkstart:kkend), interpnopt);
     end
-    dT_(isstart:isend,:,:) = interpn(dT, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
   end
   %% rename back to dT from dT_ (****)
   dT = dT_;

--- a/src/Generate_IC.m
+++ b/src/Generate_IC.m
@@ -6,19 +6,6 @@
 %% (2) Apply random seed and normalize (rand_real_norm).
 %% (3) FFT & record.
 
-%% For memory-efficient 2D interpolation, will slice k-space cube by this number
-Nslice         = 16;  %% intended # of coarse slices; may differ from the actual # of coarse slices
-if (Nmode_p <= 32)  %% safeguard & efficiency for poor-resolution IC
-  Nslice = 1
-end
-Nsubslice      = floor(Nmode_p/Nslice);
-Nfinalsubslice = mod(Nmode_p,Nslice);
-if Nfinalsubslice == 0  %% actual # of coarse slices
-  Nslice_actual = Nslice;
-else
-  Nslice_actual = Nslice+1;
-end
-
 enzo_HDF5_flag = (enzo_HDF5_flag && matlabflag);  %% HDF5 output only possible in Matlab
 %% Output binary when running Octave & the user wrongfully intends HDF5 output
 if (~enzo_bin_flag && ~matlabflag)  

--- a/src/Generate_IC.m
+++ b/src/Generate_IC.m
@@ -93,7 +93,7 @@ end
 %% Prepare for interpn, let positions run from 1:Nmode_p for unperturbed particles,
 %% to get more-accurate-than-1LPT velocity when particlevelocity_accuracyflag=true.
 %% Using mod function, the actual positions will run from 1 to Nmode_p+0.9999999...
-%% Interpolation basis will have domain 1:Nmode_p+1 for safe interpolation (see **).
+%% Interpolation basis will have domain 1:Nmode_p+1 for safe interpolation (see ***).
 if particlevelocity_accuracyflag  
   Psi1 = mod(Psi1*Nmode_p - 0.5, Nmode_p)+1;
 else
@@ -195,15 +195,24 @@ vc1                 = real(ifftn(ifftshift(vc1)));
 
 Vc1 = reshape(vc1(:,:,1) *MpcMyr_2_kms, Nmode_p, Nmode_p); %% for figure
 
+vc_1 = zeros(Nmode_p,Nmode_p,Nmode_p); %% temporary variable (see ****)
 if particlevelocity_accuracyflag
   disp('******* Calculating CDM velocity x more accurately than 1LPT **');
-  %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
+  %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (***)
   vc1 = padarray(vc1, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
-  %% Find 
-  vc1 = interpn(vc1, Psi1, Psi2, Psi3, interpnopt); %% now Nmode_p^3 elements
+  %% Find values at displaced particle locations
+  for islice=1:Nslice_actual
+    isstart = 1 + (islice-1)*Nsubslice;
+    isend   = islice*Nsubslice;
+    if islice == Nslice_actual
+      isend = Nmode_p;
+    end
+    vc_1(isstart:isend,:,:) = interpn(vc1, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
+  end
 end
-%% into enzo velocity unit
-vc1 = vc1 * MpcMyr_2_kms * 1e5 /VelocityUnits;
+%% into enzo velocity unit, and rename back to vc1 from vc_1 (****)
+vc1 = vc_1 * MpcMyr_2_kms * 1e5 /VelocityUnits;
+clear vc_1;
 
 if enzo_bin_flag
   fout = fopen([ICsubdir '/vc1'], 'w');
@@ -231,14 +240,24 @@ vc2                 = real(ifftn(ifftshift(vc2)));
 
 Vc2 = reshape(vc2(:,:,1) *MpcMyr_2_kms, Nmode_p, Nmode_p); %% for figure
 
+vc_2 = zeros(Nmode_p,Nmode_p,Nmode_p); %% temporary variable (see ****)
 if particlevelocity_accuracyflag
   disp('******* Calculating CDM velocity y more accurately than 1LPT **');
-  %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
+  %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (***)
   vc2 = padarray(vc2, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
-  %% Find 
-  vc2 = interpn(vc2, Psi1, Psi2, Psi3, interpnopt); %% now Nmode_p^3 elements
+  %% Find values at displaced particle locations
+  for islice=1:Nslice_actual
+    isstart = 1 + (islice-1)*Nsubslice;
+    isend   = islice*Nsubslice;
+    if islice == Nslice_actual
+      isend = Nmode_p;
+    end
+    vc_2(isstart:isend,:,:) = interpn(vc2, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
+  end
 end
-vc2 = vc2 * MpcMyr_2_kms * 1e5 /VelocityUnits;
+%% into enzo velocity unit, and rename back to vc2 from vc_2 (****)
+vc2 = vc_2 * MpcMyr_2_kms * 1e5 /VelocityUnits;
+clear vc_2;
 
 if enzo_bin_flag
   fout = fopen([ICsubdir '/vc2'], 'w');
@@ -258,14 +277,24 @@ vc3                 = real(ifftn(ifftshift(vc3)));
 
 Vc3 = reshape(vc3(:,:,1) *MpcMyr_2_kms, Nmode_p, Nmode_p); %% for figure
 
+vc_3 = zeros(Nmode_p,Nmode_p,Nmode_p); %% temporary variable (see ****)
 if particlevelocity_accuracyflag
   disp('******* Calculating CDM velocity y more accurately than 1LPT **');
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
   vc3 = padarray(vc3, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
-  %% Find 
-  vc3 = interpn(vc3, Psi1, Psi2, Psi3, interpnopt); %% now Nmode_p^3 elements
+  %% Find values at displaced particle locations
+  for islice=1:Nslice_actual
+    isstart = 1 + (islice-1)*Nsubslice;
+    isend   = islice*Nsubslice;
+    if islice == Nslice_actual
+      isend = Nmode_p;
+    end
+    vc_3(isstart:isend,:,:) = interpn(vc3, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
+  end
 end
-vc3 = vc3 * MpcMyr_2_kms * 1e5 /VelocityUnits;
+%% into enzo velocity unit, and rename back to vc3 from vc_3 (****)
+vc3 = vc_3 * MpcMyr_2_kms * 1e5 /VelocityUnits;
+clear vc_3;
 
 if enzo_bin_flag
   fout = fopen([ICsubdir '/vc3'], 'w');
@@ -448,12 +477,23 @@ if enzo_HDF5_flag
 end
 
 %% If SPH in mind:
+vb_1 = zeros(Nmode_p,Nmode_p,Nmode_p); %% temporary variable (see ****)
 if (particlevelocity_accuracyflag & baryonparticleflag)
   disp('******* Calculating baryon particle velocity x more accurately than 1LPT **');
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
   vb1 = padarray(vb1, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
-  %% Find 
-  vb1 = interpn(vb1, Psi1, Psi2, Psi3, interpnopt); %% now Nmode_p^3 elements
+  %% Find values at displaced particle locations
+  for islice=1:Nslice_actual
+    isstart = 1 + (islice-1)*Nsubslice;
+    isend   = islice*Nsubslice;
+    if islice == Nslice_actual
+      isend = Nmode_p;
+    end
+    vb_1(isstart:isend,:,:) = interpn(vb1, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
+  end
+  %% rename back to vb1 from vb_1 (****)
+  vb1 = vb_1;
+  clear vb_1;
   fout = fopen([ICsubdir '/vpb1'], 'w');
   fwrite(fout, vb1, 'double');
   fclose(fout);
@@ -485,12 +525,24 @@ if enzo_HDF5_flag
   h5write(foutname,datasetname, vb2, [1 1 1 2], [ND1 ND1 ND1 1]);
 end
 
+%% If SPH in mind:
+vb_2 = zeros(Nmode_p,Nmode_p,Nmode_p); %% temporary variable (see ****)
 if (particlevelocity_accuracyflag & baryonparticleflag)
   disp('******* Calculating baryon particle velocity y more accurately than 1LPT **');
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
   vb2 = padarray(vb2, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
-  %% Find 
-  vb2 = interpn(vb2, Psi1, Psi2, Psi3, interpnopt); %% now Nmode_p^3 elements
+  %% Find values at displaced particle locations
+  for islice=1:Nslice_actual
+    isstart = 1 + (islice-1)*Nsubslice;
+    isend   = islice*Nsubslice;
+    if islice == Nslice_actual
+      isend = Nmode_p;
+    end
+    vb_2(isstart:isend,:,:) = interpn(vb2, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
+  end
+  %% rename back to vb2 from vb_2 (****)
+  vb2 = vb_2;
+  clear vb_2;
   fout = fopen([ICsubdir '/vpb2'], 'w');
   fwrite(fout, vb2, 'double');
   fclose(fout);
@@ -532,12 +584,24 @@ if enzo_HDF5_flag
   h5writeatt(foutname,datasetname,'TopGridStart',  int64(zeros(1,3)));
 end
 
+%% If SPH in mind:
+vb_3 = zeros(Nmode_p,Nmode_p,Nmode_p); %% temporary variable (see ****)
 if (particlevelocity_accuracyflag & baryonparticleflag)
   disp('******* Calculating baryon particle velocity z more accurately than 1LPT **');
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
   vb3 = padarray(vb3, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
-  %% Find 
-  vb3 = interpn(vb3, Psi1, Psi2, Psi3, interpnopt); %% now Nmode_p^3 elements
+  %% Find values at displaced particle locations
+  for islice=1:Nslice_actual
+    isstart = 1 + (islice-1)*Nsubslice;
+    isend   = islice*Nsubslice;
+    if islice == Nslice_actual
+      isend = Nmode_p;
+    end
+    vb_3(isstart:isend,:,:) = interpn(vb3, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
+  end
+  %% rename back to vb3 from vb_3 (****)
+  vb3 = vb_3;
+  clear vb_3;
   fout = fopen([ICsubdir '/vpb3'], 'w');
   fwrite(fout, vb3, 'double');
   fclose(fout);
@@ -653,12 +717,23 @@ Zetot = reshape(sp_Etot_enzo(:,:,1)*VelocityUnits^2,Nmode_p,Nmode_p); %% for fig
 
 %% If SPH in mind: (this if-end statement should be placed after other dT related
 %% grid quantities are all calculated. So developers, do not change this location.)
+dT_ = zeros(Nmode_p,Nmode_p,Nmode_p); %% temporary variable (see ****)
 if (particlevelocity_accuracyflag & baryonparticleflag)
   disp('******* Calculating baryon particle thermal energy more accurately than 1LPT **');
   %% pad with periodic boundary condition, to provide 1:Nmode_p+1 domain. (**)
   dT = padarray(dT, [1 1 1], 'circular', 'post'); %% now (Nmode_p+1)^3 elements.
-  %% Find 
-  dT = interpn(dT, Psi1, Psi2, Psi3, interpnopt); %% now Nmode_p^3 elements
+  %% Find values at displaced particle locations
+  for islice=1:Nslice_actual
+    isstart = 1 + (islice-1)*Nsubslice;
+    isend   = islice*Nsubslice;
+    if islice == Nslice_actual
+      isend = Nmode_p;
+    end
+    dT_(isstart:isend,:,:) = interpn(dT, Psi1(isstart:isend,:,:), Psi2(isstart:isend,:,:), Psi3(isstart:isend,:,:), interpnopt);
+  end
+  %% rename back to dT from dT_ (****)
+  dT = dT_;
+  clear dT_;
   fout = fopen([ICsubdir '/eptherm'], 'w');
   fwrite(fout, 3/2*kb*(dT+1)*Tz /(mmw*mH) /VelocityUnits^2, 'double');
   fclose(fout);

--- a/src/bccomics.m
+++ b/src/bccomics.m
@@ -154,9 +154,7 @@ else
     k3_3D_p_chunk = cat(3, k3_3D_p_chunk, kunit_p*kkk*onesk1k2_2D);
   end
   
-  disp('---debug: k1^2+k2^2 assigning---')
   k1k2sq_p_chunk = k1_3D_p_chunk.^2 +k2_3D_p_chunk.^2; %% k1^2+k2^2
-  disp('---debug: k1^2+k2^2 assigned---')
 end
 
 %% utilize above for rvector too, but just in memory saving way (****)
@@ -170,7 +168,6 @@ dmu = mu(2)-mu(1);
 Nmu = length(mu);
 
 %% choose patch to generate initial condition on
-disp('---debug: before choose_finalpatch')
 Choose_finalpatch;  %%==== script ==================
 if returnflag
   clear;

--- a/src/bccomics.m
+++ b/src/bccomics.m
@@ -115,7 +115,6 @@ interpnopt = 'linear'
 
 %% k1 component on each (k1,k2,k3) point, etc.
 %% If memory error occurs, better to turn on memory_save (looping over k3 axis)
-memory_save = true;
 if Nmode_p<=32
   memory_save = false;
 end

--- a/src/bccomics.m
+++ b/src/bccomics.m
@@ -112,12 +112,57 @@ interpnopt = 'linear'
 %% from Briggs convention [-Nhalf_p+1:Nhalf_p], but this is
 %% to par with Matlab and Octave FFT convention.
 
+
 %% k1 component on each (k1,k2,k3) point, etc.
-[k1_3D_p, k2_3D_p, k3_3D_p] = ndgrid(-Nhalf_p:Nhalf_p-1);
-k1_3D_p = kunit_p * k1_3D_p;
-k2_3D_p = kunit_p * k2_3D_p;
-k3_3D_p = kunit_p * k3_3D_p;
-ksq_p   = k1_3D_p.^2 +k2_3D_p.^2 +k3_3D_p.^2; %% |k|^2
+%% If memory error occurs, better to turn on memory_save (looping over k3 axis)
+memory_save = true;
+if Nmode_p<=32
+  memory_save = false;
+end
+
+%% number of chunks to iterate for memory_save
+if memory_save
+  Nsub_chunk = 8;  %% # of slices to treat in one chunk
+  Nchunk = ceil(Nmode_p/Nsub_chunk);  %% check for residual slices after chunkening
+  Nsub_r = mod(Nmode_p,Nsub_chunk); %% # of residual slices
+end
+
+if ~memory_save
+  disp('---debug: assigning k1k2k3')
+  [k1_3D_p, k2_3D_p, k3_3D_p] = ndgrid(-Nhalf_p:Nhalf_p-1);
+  disp('---debug: assigned k1k2k3')
+  k1_3D_p = kunit_p * k1_3D_p;
+  k2_3D_p = kunit_p * k2_3D_p;
+  k3_3D_p = kunit_p * k3_3D_p;
+  disp('---debug: k^2 assigning---')
+  ksq_p   = k1_3D_p.^2 +k2_3D_p.^2 +k3_3D_p.^2; %% |k|^2
+  disp('---debug: k^2 assigned---')
+else
+  [k1_2D_p, k2_2D_p] = ndgrid(-Nhalf_p:Nhalf_p-1);
+  disp('---debug: assigned k1k2k3')
+  k1_2D_p = kunit_p * k1_2D_p;
+  k2_2D_p = kunit_p * k2_2D_p;
+
+  k1_3D_p_chunk = k1_2D_p;
+  k2_3D_p_chunk = k2_2D_p;
+  %% makes Nmode_p*Nmode_p*Nsub_chunk k1-vector & k2-vector array, using cat(concatenate).
+  for kkk=2:Nsub_chunk
+    k1_3D_p_chunk = cat(3, k1_3D_p_chunk, k1_2D_p);
+    k2_3D_p_chunk = cat(3, k2_3D_p_chunk, k2_2D_p);
+  end
+
+  onesk1k2_2D = ones(Nmode_p,Nmode_p);  %% ones on k1-k2 plane
+  k3_3D_p_chunk = kunit_p*(-Nhalf_p)*onesk1k2_2D;  %% 2D array at this point
+  %% makes Nmode_p*Nmode_p*Nsub_chunk k1-vector & k2-vector array, using cat(concatenate).
+  %% integer index runs from -Nhalf_p:-Nhalf_p+(Nsub_chunk-1)
+  for kkk=-Nhalf_p+1:-Nhalf_p+(Nsub_chunk-1)
+    k3_3D_p_chunk = cat(3, k3_3D_p_chunk, kunit_p*kkk*onesk1k2_2D);
+  end
+  
+  disp('---debug: k1^2+k2^2 assigning---')
+  k1k2sq_p_chunk = k1_3D_p_chunk.^2 +k2_3D_p_chunk.^2; %% k1^2+k2^2
+  disp('---debug: k1^2+k2^2 assigned---')
+end
 
 %% utilize above for rvector too, but just in memory saving way (****)
 %%r1 = k1_3D_p/kunit_p;
@@ -130,6 +175,7 @@ dmu = mu(2)-mu(1);
 Nmu = length(mu);
 
 %% choose patch to generate initial condition on
+disp('---debug: before choose_finalpatch')
 Choose_finalpatch;  %%==== script ==================
 if returnflag
   clear;
@@ -182,10 +228,28 @@ Set_gaussrand;  %%==== script ==================
 %% record random seed if wanted
 if recordseedflag
   fileNseed = [ICsubdir '/subgaussseed' num2str(Nmode_p) '.matbin'];
+  disp(['--- Seed is being recorded under ' ICsubdir ' ---']);
   if matlabflag
     save(fileNseed, 'randamp', 'randphs', '-v6');
   else
     save('-mat-binary', fileNseed, 'randamp', 'randphs');
+  end
+  %% check if wrongful (in size) matbin file is written, and if so write in simpler binary.
+  %% (Octave behaves badly when writing matbin file with big (~1000*1000*500*2)array)
+  if matlabflag
+    msg   = dir(fileNseed);
+    fsize = msg.bytes; %% file size in bytes
+  else
+    msg   = lstat(fileNseed);
+    fsize = msg.size; %% file size in bytes
+  end  
+  if (fsize < Nmode_p*Nmode_p*Nc_p*2*8)  %% randamp & randphs at 8 bytes
+    delete(fileNseed);
+    fileNseed_1 = [ICsubdir '/subgaussseed' num2str(Nmode_p) '.bin'];
+    ffout = fopen(fileNseed_1,'w');
+    fwrite(ffout, randamp, 'double');
+    fwrite(ffout, randphs, 'double');
+    fclose(ffout);
   end
 end
 
@@ -213,7 +277,31 @@ muext(Nmu-1:-1:1)  = -mu(2:Nmu);
 
 %% mu = cosine(angle between k vector and V_cb=V_c-V_b).
 %% The mu convention is consistent with f.m.
-costh_k_V = (V_cb_1_azend(ic,jc,kc)*k1_3D_p + V_cb_2_azend(ic,jc,kc)*k2_3D_p + V_cb_3_azend(ic,jc,kc)*k3_3D_p) /norm([V_cb_1_azend(ic,jc,kc) V_cb_2_azend(ic,jc,kc) V_cb_3_azend(ic,jc,kc)]) ./sqrt(ksq_p);
+disp('--- costh between V_cb and wavevector(k) being calculated ---')
+if ~memory_save
+  costh_k_V = (V_cb_1_azend(ic,jc,kc)*k1_3D_p + V_cb_2_azend(ic,jc,kc)*k2_3D_p + V_cb_3_azend(ic,jc,kc)*k3_3D_p) /norm([V_cb_1_azend(ic,jc,kc) V_cb_2_azend(ic,jc,kc) V_cb_3_azend(ic,jc,kc)]) ./sqrt(ksq_p);
+else
+  for kkchunk=1:Nchunk
+    disp(['*** ' num2str(kkchunk) ' out of ' num2str(Nchunk) ' chunks being processed ***'])
+    kkstart = 1 + (kkchunk-1)*Nsub_chunk;
+    kkend   = kkchunk*Nsub_chunk;
+    if kkchunk == Nchunk
+      kkend = Nmode_p;
+    end
+    %% k3_3D_p_chunk is defined at the bottom chunk, so need to add a shift in iteration
+    kshift = kunit_p*(kkchunk-1)*Nsub_chunk;
+    if kkchunk ~= Nchunk
+      costh_k_V(:,:,kkstart:kkend) = (V_cb_1_azend(ic,jc,kc)*k1_3D_p_chunk             + V_cb_2_azend(ic,jc,kc)*k2_3D_p_chunk             + V_cb_3_azend(ic,jc,kc)*(k3_3D_p_chunk            +kshift)) /norm([V_cb_1_azend(ic,jc,kc) V_cb_2_azend(ic,jc,kc) V_cb_3_azend(ic,jc,kc)]) ./sqrt(k1k2sq_p_chunk            +(k3_3D_p_chunk            +kshift).^2);
+    else %% the last chunk
+      if Nsub_r == 0
+        Nsub = Nsub_chunk;
+      else
+        Nsub = Nsub_r;
+      end
+      costh_k_V(:,:,kkstart:kkend) = (V_cb_1_azend(ic,jc,kc)*k1_3D_p_chunk(:,:,1:Nsub) + V_cb_2_azend(ic,jc,kc)*k2_3D_p_chunk(:,:,1:Nsub) + V_cb_3_azend(ic,jc,kc)*(k3_3D_p_chunk(:,:,1:Nsub)+kshift)) /norm([V_cb_1_azend(ic,jc,kc) V_cb_2_azend(ic,jc,kc) V_cb_3_azend(ic,jc,kc)]) ./sqrt(k1k2sq_p_chunk(:,:,1:Nsub)+(k3_3D_p_chunk(:,:,1:Nsub)+kshift).^2);
+    end
+  end
+end
 
 %% Generate and dump initial condition data
 Generate_IC;  %%==== script ==================

--- a/src/bccomics.m
+++ b/src/bccomics.m
@@ -128,18 +128,13 @@ if memory_save
 end
 
 if ~memory_save
-  disp('---debug: assigning k1k2k3')
   [k1_3D_p, k2_3D_p, k3_3D_p] = ndgrid(-Nhalf_p:Nhalf_p-1);
-  disp('---debug: assigned k1k2k3')
   k1_3D_p = kunit_p * k1_3D_p;
   k2_3D_p = kunit_p * k2_3D_p;
   k3_3D_p = kunit_p * k3_3D_p;
-  disp('---debug: k^2 assigning---')
   ksq_p   = k1_3D_p.^2 +k2_3D_p.^2 +k3_3D_p.^2; %% |k|^2
-  disp('---debug: k^2 assigned---')
 else
   [k1_2D_p, k2_2D_p] = ndgrid(-Nhalf_p:Nhalf_p-1);
-  disp('---debug: assigned k1k2k3')
   k1_2D_p = kunit_p * k1_2D_p;
   k2_2D_p = kunit_p * k2_2D_p;
 


### PR DESCRIPTION
- Further memory optimization on k1_3D_p, k2_3D_p, k3_3D_p, ksq_p. So overall about 8*4*Nmode_p^3 byte is saved.

- interpn also is called in sliced chunks of Psi1, Psi2, Psi3 data.